### PR TITLE
move symlinks to python, in line with other runtime repos

### DIFF
--- a/.gradient/automated-test.sh
+++ b/.gradient/automated-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#! /usr/bin/env bash
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 #
 # The entry point for the automated testing on the Paperspace platform

--- a/.gradient/symlink_config.json
+++ b/.gradient/symlink_config.json
@@ -1,0 +1,8 @@
+{
+    "${POPLAR_EXECUTABLE_CACHE_DIR}":["${PUBLIC_DATASETS_DIR}/poplar-executables-pyg-3-2"],
+    "${DATASETS_DIR}/Cora":["${PUBLIC_DATASETS_DIR}/pyg-cora"],
+    "${DATASETS_DIR}/FB15k-237":["${PUBLIC_DATASETS_DIR}/pyg-fb15k-237"],
+    "${DATASETS_DIR}/qm9":["${PUBLIC_DATASETS_DIR}/pyg-qm9"],
+    "${DATASETS_DIR}/Reddit":["${PUBLIC_DATASETS_DIR}/pyg-reddit"],
+    "${DATASETS_DIR}/TUDataset":["${PUBLIC_DATASETS_DIR}/pyg-tudataset"]
+}

--- a/.gradient/symlink_datasets_and_caches.py
+++ b/.gradient/symlink_datasets_and_caches.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env -S python3 -u
+import json
+import time
+from pathlib import Path
+import subprocess
+import os
+import warnings
+from typing import List
+
+def check_dataset_is_mounted(source_dirs_list: List[str]) -> List[str]:
+    source_dirs_exist_paths = []
+    for source_dir in source_dirs_list:
+        source_dir_path = Path(source_dir)
+        COUNTER = 0
+        # wait until the dataset exists and is populated/non-empty, with a 300s/5m timeout
+        while (COUNTER < 300) and (not source_dir_path.exists() or not any(source_dir_path.iterdir())):
+            print(f"Waiting for dataset {source_dir_path.as_posix()} to be mounted...")
+            time.sleep(1)
+            COUNTER += 1
+
+        if COUNTER == 300:
+            warnings.warn(f"Abandoning symlink! - source dataset {source_dir} has not been mounted & populated after 5 minutes.")
+        else:
+            print(f"Found dataset {source_dir}")
+            source_dirs_exist_paths.append(source_dir)
+
+    return source_dirs_exist_paths
+
+
+def create_overlays(source_dirs_exist_paths: List[str], target_dir: str) -> None:
+    print(f"Symlinking - {source_dirs_exist_paths} to {target_dir}")
+    print("-" * 100)
+
+    Path(target_dir).mkdir(parents=True, exist_ok=True)
+
+    workdir = Path("/fusedoverlay/workdirs" + source_dirs_exist_paths[0])
+    workdir.mkdir(parents=True, exist_ok=True)
+    upperdir = Path("/fusedoverlay/upperdir" + source_dirs_exist_paths[0]) 
+    upperdir.mkdir(parents=True, exist_ok=True)
+
+    lowerdirs = ":".join(source_dirs_exist_paths)
+    overlay_command = f"fuse-overlayfs -o lowerdir={lowerdirs},upperdir={upperdir.as_posix()},workdir={workdir.as_posix()} {target_dir}"
+    subprocess.run(overlay_command.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+    return
+
+
+def main():
+    # read in symlink config file
+    json_data = (Path(__file__).resolve().parent / "symlink_config.json").read_text()
+
+    # substitute environment variables in the JSON data
+    json_data = os.path.expandvars(json_data)
+    config = json.loads(json_data)
+
+    # loop through each key-value pair
+    # the key is the target directory, the value is a list of source directories
+    for target_dir, source_dirs_list in config.items():
+        # need to wait until the dataset has been mounted (async on Paperspace's end)
+        source_dirs_exist_paths = check_dataset_is_mounted(source_dirs_list)
+        
+        # create overlays for source dataset dirs that are mounted and populated
+        if len(source_dirs_exist_paths) > 0:
+            create_overlays(source_dirs_exist_paths, target_dir)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR duplicates what was done in the other 3 runtimes, to move the symlinking code to a json config and python script, to make it more easily extendable and manageable. Pytorch runtime reference PR: https://github.com/gradient-ai/Graphcore-Pytorch/pull/52/files

Testing done:
Use `diff` and `tree` to compare the sorted tree structure of the `tmp` directory for a Paperspace notebook started using the main branch vs this feature branch, and verify they are identical. Steps:
1. Created 2 notebooks on paperspace, one on main branch, one on this feature branch. For each notebook, after setup.sh etc. finished executing, start a terminal, then
2. `apt-get update -y && apt-get -y install tree`
3. `cd /tmp`
4. `tree -afi > /notebooks/<branchname>.tree`
5. Download the 2 `.tree` files to local machine, then do `diff main.tree feature.tree` and verify there's no difference between the two. 